### PR TITLE
Fix link to tours page

### DIFF
--- a/schedule-de.html
+++ b/schedule-de.html
@@ -24,7 +24,7 @@ banner: schedule-banner
     <div class="feature-description">
       <p>
         Lerne einen Space bei einer geführten Tour im Detail kennen. Es gibt Touren für einzelne oder mehre Spaces.
-        Mehr unter <a href="./tours-de.html">Touren</a>.
+        Mehr unter <a href="./../tours-de">Touren</a>.
       </p>
     </div>
   </section>

--- a/schedule.html
+++ b/schedule.html
@@ -38,7 +38,7 @@ banner: schedule-banner
     <h3 class="feature-title">Tour & Explore</h3>
     <div class="feature-description">
       <p>
-        Learn more about a space through an organized tour. Each space is unique, the amenities vary, and each community is different. Check out a space near you and join a tour. See <a href="./tours.html">Tours</a> for details.
+        Learn more about a space through an organized tour. Each space is unique, the amenities vary, and each community is different. Check out a space near you and join a tour. See <a href="./../tours">Tours</a> for details.
       </p>
     </div>
   </section>


### PR DESCRIPTION
The link to the tours page was broken (on the german and english schedule pages). Fixed the path.